### PR TITLE
little errors with server. fixing the authenticateToken crashes

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -164,18 +164,18 @@ app.use('/api/yourpage/events/myEvents/:userId',async (req,res,next)=>{
 // })
 
 // https://stackoverflow.com/questions/27117337/exclude-route-from-express-middleware
-var unless = function(path, middleware) {
-    return function(req, res, next) {
-        if (path === req.path) {
-            return next();
-        } else {
+var unless = function(paths, middleware) {
+    return function(req,res,next) {
+        if (req.path.startsWith('/api') && !paths.includes(req.path)) {
             return middleware(req, res, next);
+        } else {
+            return next();
         }
-    };
+    }
 };
 // Initialize Firebase, unless for unprotected routes
-app.use(unless('/api/signup', decodeIDToken));
-app.use(unless('/api/users/:id', decodeIDToken));
+const exclude = ['/api/signup', '/api/users/:id'];
+app.use(unless(exclude, decodeIDToken));
 
 const getAuthToken = (req, res, next) => {
     if (req.headers.authorization &&

--- a/server/authenticateToken.js
+++ b/server/authenticateToken.js
@@ -18,6 +18,7 @@ initializeApp({
 
 async function decodeIDToken(req, res, next) {
     const header = req.headers.authorization;
+    if (!header) return res.json({error: 'Unauthorized!'});
     if (header !== 'Bearer null' && req.headers.authorization.startsWith('Bearer ')) {
         const idToken = req.headers.authorization.split('Bearer ')[1];
         try {


### PR DESCRIPTION
made it so authneticateToken middleware only gets run on the API routes, not the base routes. also made it so it won't crash the server but will simply return unauthenticated if no header